### PR TITLE
fix(template): Remove duplicate extends in edit_contact.html

### DIFF
--- a/templates/edit_contact.html
+++ b/templates/edit_contact.html
@@ -1,7 +1,5 @@
 {% extends "base.html" %}
 
-{% extends "base.html" %}
-
 {% block title %}Edit Contact{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
The `templates/edit_contact.html` template contained a duplicate `{% extends "base.html" %}` directive. This caused a `jinja2.exceptions.TemplateRuntimeError: extended multiple times` when a user tried to access the "Edit Contact" page, resulting in a server error.

This commit removes the redundant line, which resolves the template rendering error and allows the page to load correctly.