### PR TITLE
fix: Correct bugs on Edit Contact page

### DIFF
--- a/app.py
+++ b/app.py
@@ -308,7 +308,7 @@ def edit_contact(contact_id):
     contact = None
     try:
         cur = conn.cursor()
-        cur.execute("SELECT id, name, email, phone, passport_number, drivers_license_number, medicare_number, user_id FROM contacts WHERE id = ?", (contact_id,))
+        cur.execute("SELECT * FROM contacts WHERE id = ?", (contact_id,))
         contact = cur.fetchone()
     except sqlite3.Error as e:
         print(f"Database error: {e}")

--- a/templates/edit_contact.html
+++ b/templates/edit_contact.html
@@ -1,7 +1,5 @@
 {% extends "base.html" %}
 
-{% extends "base.html" %}
-
 {% block title %}Edit Contact{% endblock %}
 
 {% block content %}


### PR DESCRIPTION
This commit addresses two issues on the "Edit Contact" page:

1.  A `jinja2.exceptions.TemplateRuntimeError: extended multiple times` was occurring due to a duplicate `{% extends "base.html" %}` directive in the `edit_contact.html` template. The redundant directive has been removed.

2.  Links to previously uploaded files were not being displayed. This was because the SQL query in the `edit_contact` function was not selecting the filename columns from the database. The query has been updated from a selective list of columns to `SELECT *` to ensure all contact data is fetched. This is consistent with other queries in the application.